### PR TITLE
fix : board create, get 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,6 +54,7 @@ export class AppModule implements NestModule {
       .forRoutes(
         { path: 'user/update', method: RequestMethod.PUT },
         { path: 'board', method: RequestMethod.POST },
+        { path: 'board', method: RequestMethod.GET },
         { path: 'board/member/:board_id', method: RequestMethod.POST },
         { path: 'board/waiting/:board_id', method: RequestMethod.POST },
         { path: 'comment/:card_id', method: RequestMethod.POST },

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -33,11 +33,7 @@ export class BoardController {
   }
 
   @Post('/')
-  createBoard(
-    @Body() data: CreateBoardDto,
-    @Res({ passthrough: true }) res: Response,
-    @Req() request: RequestWithLocals,
-  ) {
+  createBoard(@Body() data: CreateBoardDto, @Req() request: RequestWithLocals) {
     const user = request.locals.user;
     return this.boardService.createBoard(
       user.id,

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -30,7 +30,13 @@ export class BoardService {
             .where(`member.user_id = ${user_id} AND deletedAt IS NULL`)
             .getQuery(),
       )
-      .select(['board_id', 'user_id', 'name', 'color', 'description'])
+      .select([
+        'board.board_id',
+        'board.user_id',
+        'board.name',
+        'board.color',
+        'board.description',
+      ])
       .getMany();
   }
 
@@ -40,12 +46,18 @@ export class BoardService {
     color: BoardColor,
     description: string,
   ) {
-    this.boardRepository.insert({
+    const boardCreate = await this.boardRepository.insert({
       user_id,
       name,
       color,
       description,
     });
+    if (boardCreate) {
+      await this.memberRepository.insert({
+        user_id,
+        board_id: boardCreate.identifiers[0].board_id,
+      });
+    }
   }
 
   async getWaitings() {


### PR DESCRIPTION
createBoard:
보드 생성시 생성한 유저의 아이디가 member테이블의 userid가 등록되도록 설정

getBoards:
빈 배열로 나온 부분 쿼리문에 board의 컬럼이 인식을 못하는 부분을 board.을 붙여서 나오게 해줌.