### PR TITLE
fix : 프론트엔드 수정 / 멤버요청, 보드 생성

### DIFF
--- a/public/newmain.html
+++ b/public/newmain.html
@@ -110,7 +110,6 @@
               생성
             </button>
           </div>
-
         </div>
       </div>
     </div>
@@ -226,6 +225,11 @@
                   placeholder="비밀번호를 다시 입력하세요"
                 />
               </div>
+              <div
+                class="alert alert-danger"
+                id="signError"
+                style="display: none"
+              ></div>
             </form>
           </div>
           <div class="modal-footer">
@@ -276,6 +280,11 @@
                   placeholder="비밀번호를 입력하세요"
                 />
               </div>
+              <div
+                class="alert alert-danger"
+                id="loginError"
+                style="display: none"
+              ></div>
             </form>
           </div>
           <div class="modal-footer">

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -45,6 +45,7 @@ export class BoardController {
   @Post('/')
   createBoard(@Body() data: CreateBoardDto, @Req() request: RequestWithLocals) {
     const user = request.locals.user;
+    console.log('컨트롤러', user);
     return this.boardService.createBoard(
       user.id,
       data.name,

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -71,7 +71,6 @@ export class BoardService {
   }
 
   async getWaitings(user_id: number) {
-
     return await this.waitingRepository.query(
       `SELECT waiting.board_id, board.name as name
            FROM waiting
@@ -79,7 +78,6 @@ export class BoardService {
           WHERE waiting.user_id = ${user_id}`,
     );
   }
-  
 
   async createWaiting(board_id: number, userId: number, inviteEmail: string) {
     try {
@@ -99,14 +97,15 @@ export class BoardService {
         throw new BadRequestException('본인을 초대할 수 없습니다.');
       }
       const checkWaitUser = await this.waitingRepository.findOne({
-        where: { user_id: inviteUser.user_id },
+        where: { user_id: inviteUser.user_id, board_id },
       });
       if (checkWaitUser) {
         throw new BadRequestException('초대중인 유저입니다.');
       }
       const checkMemberUser = await this.memberRepository.findOne({
-        where: { user_id: inviteUser.user_id },
+        where: { user_id: inviteUser.user_id, board_id },
       });
+      console.log(checkMemberUser);
       if (checkMemberUser) {
         throw new BadRequestException('초대가 완료된 유저입니다.');
       }


### PR DESCRIPTION
로그인 실패 했을 때 모달창 밑에 에러 내용 뜨게 해주기
회원가입 실패 했을 때 모달창 밑에 에러 내용 뜨게 해주기
user login / createUser 에서 에러 try catch사용해서 throw error로 보내기 멤버요청 수락하거나 취소 시 멤버요청 리스트 아이템 삭제
보드 생성 시 jwtToken을 보내 user_id가 입력되도록 newmain.ts 추가(175번째줄부터)